### PR TITLE
add cli spinner when performing rake task

### DIFF
--- a/lib/tasks/update_release_notes.rake
+++ b/lib/tasks/update_release_notes.rake
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require "whirly"
+
 namespace :update_release_notes do
   task run: :environment do
-    Release::Notes::Update.new.run
+    Whirly.start spinner: "dots", status: "Generating release-notes...", remove_after_stop: true do
+      Release::Notes::Update.new.run
+    end
   end
 end

--- a/release-notes.gemspec
+++ b/release-notes.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport'
-
+  spec.add_dependency 'whirly'
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
The first time you run update release notes, it can take up to a couple seconds to finish performing the command. This PR adds a spinner to the cli to let the user know that something is happening, instead of showing nothing and potentially leading the user to think the task is not executing.