### PR TITLE
Remove extra header underline

### DIFF
--- a/lib/release/notes/write.rb
+++ b/lib/release/notes/write.rb
@@ -66,7 +66,7 @@ module Release
       def new_temp_file_template
         File.new(temp_file, "w")
         File.open(temp_file, "a") do |fi|
-          fi << "# Release Notes\n----------------------"
+          fi << "# Release Notes\n"
         end
       end
     end


### PR DESCRIPTION
![screen shot 2018-11-09 at 10 59 56 pm](https://user-images.githubusercontent.com/18423853/48297324-4da79380-e473-11e8-8f29-0e5fe94bea82.png)
Remove this extra line from the release notes. H1's in markdown are automatically underlined, so this is redundant.