### PR TITLE
wrap release notes task with puts

### DIFF
--- a/lib/tasks/update_release_notes.rake
+++ b/lib/tasks/update_release_notes.rake
@@ -2,6 +2,8 @@
 
 namespace :update_release_notes do
   task run: :environment do
+    p 'generating release notes...'
     Release::Notes::Update.new.run
+    p 'done!'
   end
 end


### PR DESCRIPTION
Instead of adding a more intricate spinner, this PR wraps the rake task with console messages to alert the user that the task is running.