### PR TITLE
remove extra new line ;B

### DIFF
--- a/lib/release/notes/write.rb
+++ b/lib/release/notes/write.rb
@@ -20,7 +20,7 @@ module Release
 
       def digest(date: nil, title: nil, log_message: nil)
         File.open(temp_file, "a") do |fi|
-          fi << "\n\n## #{date}\n" if date
+          fi << "\n## #{date}\n" if date
           fi << "\n#{title}\n\n" if title && !date
           fi << "#{title}\n\n" if title && date
 


### PR DESCRIPTION
Currently, an extra new line is added before the date:

```
## November 18, 2018 11:14:13 AM EST

**Implemented enhancements:**

- [[LabelBC #4]](https:\/\/label-bc\/projects) test commit 36 
- [[ReleaseNotesDemo #2]](https:\/\/release-notes-demo\/projects) test commit 18 
- [[ReleaseNotesDemo #0]](https:\/\/release-notes-demo\/projects) test commit 0

**Fixed bugs:**

- [[ReleaseNotesDemo #3]](https:\/\/release-notes-demo\/projects) test commit 27

**Miscellaneous:**

- [[LabelBC #1]](https:\/\/label-bc\/projects) test commit 9

(EXTRA NEWLINE)
## November 18, 2018 11:14:13 AM EST

**Implemented enhancements:**

- [[LabelAB #3]](https:\/\/label-ab\/projects) test commit 24

**Fixed bugs:**

- [[LabelAB #4]](https:\/\/label-ab\/projects) test commit 32

**Miscellaneous:**

- [[ReleaseNotesDemo #2]](https:\/\/release-notes-demo\/projects) test commit 16 
- [[LabelBC #1]](https:\/\/label-bc\/projects) test commit 8 
- [[LabelBC #0]](https:\/\/label-bc\/projects) test commit 0

(EXTRA NEWLINE)
## November 18, 2018 11:14:13 AM EST
....
```

This PR should fix that behavior.