### PR TITLE
remove env from rake task ;B

### DIFF
--- a/lib/tasks/update_release_notes.rake
+++ b/lib/tasks/update_release_notes.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :update_release_notes do
-  task run: :environment do
+  task :run do
     puts "generating release notes..."
     Release::Notes::Update.new.run
     puts "done!"

--- a/spec/tasks/update_release_notes_spec.rb
+++ b/spec/tasks/update_release_notes_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe "update_release_notes:run" do
     allow_any_instance_of(Release::Notes::Update).to receive(:run) { true }
   end
 
-  describe "basic rake" do
-    subject { super().prerequisites }
-    it { is_expected.to include("environment") }
-  end
-
   it "runs gracefully with no subscribers" do
     expect { subject.execute }.not_to raise_error
   end


### PR DESCRIPTION
# Bug Fix

## Description

Having environment in the in the update release notes task causes an error in a non-Rails environment.
`Don't know how to build task 'environment' (see --tasks)`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have rebased the branch with the latest code from master
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, and at the top of new interactors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing
