### PR TITLE
Fix error when tracking commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Release::Notes.configure do |config|
   config.temp_file = './release-notes.tmp.md'
   config.include_merges = false
   config.ignore_case = true
-  config.log_format = '- %s'
   config.extended_regex = true
   config.header_title = "tag"
   config.bug_labels = %w(Fix Update)

--- a/lib/generators/release/notes/install/templates/release_notes.rb
+++ b/lib/generators/release/notes/install/templates/release_notes.rb
@@ -24,12 +24,6 @@ Release::Notes.configure do |config|
   # @return [Boolean]
   # config.ignore_case = true
 
-  # Allows you to specify what information you want to print from your git log
-  # Defaults to `%s` for subject. For more, see
-  # [Git Log Docs](https://git-scm.com/docs/git-log)
-  # @return [String]
-  # config.log_format = "- %s"
-
   # Consider the limiting patterns to be extended regular expressions patterns
   # when printing your git log.
   # Defaults to `true`. For more, see

--- a/lib/release/notes/configuration.rb
+++ b/lib/release/notes/configuration.rb
@@ -33,12 +33,6 @@ module Release
       # @return [Boolean]
       attr_accessor :extended_regex
 
-      # Allows you to specify what information you want to print from your git log
-      # Defaults to `%s` for subject. For more, see
-      # [Git Log Docs](https://git-scm.com/docs/git-log)
-      # @return [String]
-      attr_accessor :log_format
-
       # Controls the headers that will be used for your tags
       # Defaults to `tag`.
       # @return [String]
@@ -138,7 +132,6 @@ module Release
         @include_merges        = false
         @ignore_case           = true
         @extended_regex        = true
-        @log_format            = "- %s"
         @header_title          = "tag"
         @bug_labels            = %w(Fix Update)
         @feature_labels        = %w(Add Create)

--- a/lib/release/notes/git.rb
+++ b/lib/release/notes/git.rb
@@ -8,7 +8,7 @@ module Release
       extend ActiveSupport::Concern
 
       included do
-        delegate :all_labels, :log_format, :grep_insensitive?,
+        delegate :all_labels, :grep_insensitive?,
                  :regex_type, :include_merges?, to: :"Release::Notes.configuration"
 
         def log(**opts)
@@ -17,6 +17,10 @@ module Release
             " #{regex_type} #{grep_insensitive?}" \
             " #{include_merges?} --format='%h #{log_format}'"
         end
+      end
+
+      def log_format
+        "- %s"
       end
 
       def first_commit

--- a/lib/release/notes/log.rb
+++ b/lib/release/notes/log.rb
@@ -34,12 +34,12 @@ module Release
       # @api private
       def copy_single_tag_of_activity(tag_from:, tag_to: "HEAD")
         [features, bugs, misc].each_with_index do |regex, i|
-          log_single_commit(regex: regex, title: titles[i], tag_from: tag_from, tag_to: tag_to)
+          find_commits(regex: regex, title: titles[i], tag_from: tag_from, tag_to: tag_to)
         end
 
         return unless log_all
 
-        log_single_commit(title: log_all_title, tag_from: tag_from, tag_to: tag_to)
+        find_commits(title: log_all_title, tag_from: tag_from, tag_to: tag_to)
       end
 
       # @api private
@@ -92,22 +92,35 @@ module Release
       end
 
       # @api private
-      def log_single_commit(tag_from:, tag_to:, title:, regex: nil, log_all: false)
+      def find_commits(tag_from:, tag_to:, title:, regex: nil, log_all: false)
         log = system_log(
           tag_from: tag_from,
           tag_to: tag_to,
           label: regex,
           log_all: log_all,
-        ).split(/(?=-)/)
-
-        commit_hash = log[0]
+        )
 
         return unless log.present?
-        return if single_label && @_commits.include?(commit_hash)
 
-        @_commits << commit_hash
-        digest_title(title: title, log_message: log[1])
+        log_messages = log.split("\n").map { |x| x.split(/(?=-)/) }
+        commit_hashes = log_messages.flat_map { |msg| msg[0].strip }
+
+        commit_hashes.dup.each do |commit|
+          commit_hashes.delete commit if single_label && @_commits.include?(commit)
+        end
+
+        return unless commit_hashes.present?
+
+        messages = log_messages.map do |msg|
+          msg[1..-1].join if commit_hashes.include?(msg[0].strip)
+        end
+
+        @_commits += commit_hashes
+
+        digest_title(title: title, log_message: "#{messages.join("\n")}\n")
       end
+
+      def log_grouped_commits(commit:, title:); end
 
       def previous_tag(index)
         git_all_tags[index + 1].present? ? git_all_tags[index + 1] : System.first_commit

--- a/lib/release/notes/log.rb
+++ b/lib/release/notes/log.rb
@@ -34,12 +34,14 @@ module Release
       # @api private
       def copy_single_tag_of_activity(tag_from:, tag_to: "HEAD")
         [features, bugs, misc].each_with_index do |regex, i|
-          find_commits(regex: regex, title: titles[i], tag_from: tag_from, tag_to: tag_to)
+          log = system_log(tag_from: tag_from, tag_to: tag_to, label: regex, log_all: log_all)
+          log_grouped_commits(title: titles[i], log: log)
         end
 
         return unless log_all
 
-        find_commits(title: log_all_title, tag_from: tag_from, tag_to: tag_to)
+        log = system_log(tag_from: tag_from, tag_to: tag_to)
+        log_grouped_commits(title: log_all_title, log: log)
       end
 
       # @api private
@@ -91,15 +93,7 @@ module Release
         digest_header(date_and_tag[header_title_type.to_sym])
       end
 
-      # @api private
-      def find_commits(tag_from:, tag_to:, title:, regex: nil, log_all: false)
-        log = system_log(
-          tag_from: tag_from,
-          tag_to: tag_to,
-          label: regex,
-          log_all: log_all,
-        )
-
+      def log_grouped_commits(log:, title:) # rubocop:disable Metrics/AbcSize
         return unless log.present?
 
         log_messages = log.split("\n").map { |x| x.split(/(?=-)/) }
@@ -119,8 +113,6 @@ module Release
 
         digest_title(title: title, log_message: "#{messages.join("\n")}\n")
       end
-
-      def log_grouped_commits(commit:, title:); end
 
       def previous_tag(index)
         git_all_tags[index + 1].present? ? git_all_tags[index + 1] : System.first_commit

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -120,4 +120,71 @@ describe Release::Notes do
       end
     end
   end
+
+  describe "commit message contains `-` " do
+    it "does not mess up formatting" do
+      within_spec_integration do
+        2.times { git_commit("Fix me - and more - this is more") } && git_tag(1)
+        Release::Notes.generate
+
+        content = read_file
+
+        file = <<~FILE
+          # Release Notes
+
+          ## v0.1.0
+
+          **Fixed bugs:**
+
+          - Fix me - and more - this is more
+        FILE
+
+        expect(content).to eq(file)
+      end
+    end
+  end
+
+  describe "multiple commit messages for a single tag" do
+    it "does not duplicate the headers" do
+      within_spec_integration do
+        (1..4).each { |v| 2.times { git_commit("Add me") } && git_tag(v) }
+        Release::Notes.generate
+
+        content = read_file
+
+        file = <<~FILE
+          # Release Notes
+
+          ## v0.4.0
+
+          **Implemented enhancements:**
+
+          - Add me
+          - Add me
+
+          ## v0.3.0
+
+          **Implemented enhancements:**
+
+          - Add me
+          - Add me
+
+          ## v0.2.0
+
+          **Implemented enhancements:**
+
+          - Add me
+          - Add me
+
+          ## v0.1.0
+
+          **Implemented enhancements:**
+
+          - Add me
+        FILE
+
+        expect(content).to eq(file)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We're splitting the message in accordance
with the formatting. But if the message has a
dash in it - we weren't logging the entire message.

There is actually more of an issue here - that is -
if the user changes the format of the git log in the
configuration. This would not work properly. Will look
into.

Fixes #60

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have rebased the branch with the latest code from master
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, and at the top of new interactors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The build is passing

