### PR TITLE
Add ability to test against ruby 2.6.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5.3
+  TargetRubyVersion: 2.6.0
   Exclude:
     - "bin/*"
     - "./**/*.gemspec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4.1
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 cache: bundler
 before_install: gem install bundler -v 1.17.1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
   - 2.4.5
   - 2.5.3
   - 2.6.0

--- a/release-notes.gemspec
+++ b/release-notes.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "pry", "~> 0.12.2"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rubocop", "~> 0.60.0"
+  spec.add_development_dependency "rubocop", "~> 0.61.0"
 end


### PR DESCRIPTION
# Feature

## Description

Now that ruby 2.6 is out, we should run ci against it so this gem can be used on 2.6 apps.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have rebased the branch with the latest code from master
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing