### PR TITLE
fix yardoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Release::Notes
 
 [![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc-release_notes-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc-Release::Notes-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
 
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Release::Notes
 
 [![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc-release-notes-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc-release_notes-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
 
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-green.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
 [![Documentation](http://img.shields.io/badge/rdoc-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)
 
+[![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # Release::Notes
 
-[![Version         ][rubygems_badge]][rubygems]
+[![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-green.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 # Release::Notes
 
 [![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)
+
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
-[![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Release::Notes
 
 [![Gem Version](https://badge.fury.io/rb/release-notes.svg)](https://badge.fury.io/rb/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc-release-notes-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
 
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
+[![Documentation](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 
@@ -87,7 +88,7 @@ end
 ```
 
 For more information about each individual setting checkout Release::Notes's
-[config docs](http://www.rubydoc.info/github/dvmonroe/release-notes/master/Release/Notes/Configuration).
+[config docs](https://www.rubydoc.info/gems/release-notes).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rubydoc-rdoc-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 # Release::Notes
 
+[![Version         ][rubygems_badge]][rubygems]
 [![Build Status](https://travis-ci.org/dvmonroe/release-notes.svg?branch=master)](https://travis-ci.org/dvmonroe/release-notes)
 [![Code Climate](https://codeclimate.com/github/dvmonroe/release-notes/badges/gpa.svg)](https://codeclimate.com/github/dvmonroe/release-notes)
 [![Test Coverage](https://codeclimate.com/github/dvmonroe/release-notes/badges/coverage.svg)](https://codeclimate.com/github/dvmonroe/release-notes/coverage)
 [![Inline docs](http://inch-ci.org/github/dvmonroe/release-notes.svg?branch=master)](http://inch-ci.org/github/dvmonroe/release-notes)
-[![Documentation](http://img.shields.io/badge/rubydoc-rdoc-blue.svg)](https://www.rubydoc.info/gems/release-notes)
+[![Documentation](http://img.shields.io/badge/rdoc.info-v1.3.0-blue.svg)](https://www.rubydoc.info/gems/release-notes)
 
 ## Automated release notes based on your project's git log.
 


### PR DESCRIPTION
# Enhancement

## Description

Current [yardoc link](https://www.rubydoc.info/github/dvmonroe/release-notes/master/Release/Notes/Configuration) takes you to documentation for an older version of the gem. This PR updates that link to point at the current documentation, as well as changes up some of the readme badges.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have rebased the branch with the latest code from master
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, and at the top of new interactors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing

## Testing

Switch to this branch and checkout the github readme -> [here](https://github.com/dvmonroe/release-notes/tree/update-readme-for-yard)