### PR TITLE
[Refactor] Log.rb for readability/maintainability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.5
   - 2.5.3
   - 2.6.0
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,15 +92,20 @@
 
 ## v1.0.1
 
+**Fixed bugs:**
+
+- Update README.md
+- Remove environment from rake task
+- Fix contributing.md
+
+## v1.0.0
+
 **Implemented enhancements:**
 
 - Updates to README, CONTRIBUTING and add bin/test
 
 **Fixed bugs:**
 
-- Update README.md
-- Remove environment from rake task
-- Fix contributing.md
 - Fix linking/writing of none linked lines and frozen string modification
 - Fix guard clause for rubocop
 
@@ -109,8 +114,6 @@
 - Update README and install template
 
 ## v1.0.0.pre
-
-## v1.0.0
 
 **Implemented enhancements:**
 

--- a/lib/release/notes.rb
+++ b/lib/release/notes.rb
@@ -15,23 +15,29 @@ require "release/notes/system"
 
 require "release/notes/write"
 require "release/notes/log"
+require "release/notes/tag"
+require "release/notes/commits"
 
 require "release/notes/railtie" if defined?(Rails)
 require "release/notes/install" unless defined?(Rails)
 
 module Release
   module Notes
+    NEWLINE = "\n"
+
     class << self
       def generate
         log.perform
       end
 
-      def log
-        Release::Notes::Log.new
-      end
-
       def root
         File.expand_path("..", __dir__)
+      end
+
+      private
+
+      def log
+        Log.new
       end
     end
   end

--- a/lib/release/notes/commits.rb
+++ b/lib/release/notes/commits.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Release
+  module Notes
+    class Commits
+      include Configurable
+      REGEX_DELIMETER = /(?=-)/
+
+      attr_reader :title, :value
+      delegate :digest_title, prefix: :writer, to: :@writer
+
+      def initialize(title:, value:, writer:, tagger:)
+        @title = title
+        @value = value
+        @writer = writer
+
+        @tagger = tagger
+      end
+
+      def perform
+        choose_messages_by_hash.tap do |obj|
+          next if obj.empty?
+
+          @tagger._hashes += obj.keys
+          output_unique_messages(obj.values)
+        end
+
+        self
+      end
+
+      private
+
+      # @api private
+      def choose_messages_by_hash
+        split_commits.tap do |obj|
+          remove_duplicate_hashes(obj)
+        end
+      end
+
+      # @api private
+      def create_commits_hash(arr, hsh)
+        hsh[arr[0].strip] = arr[1..-1].join
+      end
+
+      # @api private
+      def duplicate_commit?(key)
+        config_single_label && @tagger._hashes.include?(key)
+      end
+
+      # @api private
+      def join_messages(arr)
+        "#{arr.join(NEWLINE)}#{NEWLINE}"
+      end
+
+      # @api private
+      def output_unique_messages(messages)
+        writer_digest_title(title: title, log_message: join_messages(messages))
+      end
+
+      # @api private
+      def remove_duplicate_hashes(obj)
+        obj.keys.each { |key| obj.delete(key) if duplicate_commit?(key) }
+      end
+
+      # @api private
+      def split_commits
+        split_values do |arr, obj|
+          arr.split(REGEX_DELIMETER).tap do |split_arr|
+            create_commits_hash(split_arr, obj)
+          end
+        end
+      end
+
+      # @api private
+      def split_values(&_block)
+        value.split(NEWLINE).each_with_object({}) do |arr, obj|
+          yield arr, obj
+        end
+      end
+    end
+  end
+end

--- a/lib/release/notes/date_formatter.rb
+++ b/lib/release/notes/date_formatter.rb
@@ -5,6 +5,7 @@ module Release
     class DateFormatter
       include Configurable
       attr_reader :date
+      HUMANIZED = "%B %d, %Y %r %Z"
 
       def initialize(date = nil)
         Time.zone = config_timezone
@@ -13,7 +14,7 @@ module Release
       end
 
       def humanize
-        date.strftime("%B %d, %Y %r %Z")
+        date.strftime(HUMANIZED)
       end
     end
   end

--- a/lib/release/notes/git.rb
+++ b/lib/release/notes/git.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+require "pry"
 
 module Release
   module Notes
     class Git
       class << self
         include Configurable
+        DEFAULT_TAG = "HEAD"
 
         def log(**opts)
           "git log '#{opts[:tag_from]}'..'#{opts[:tag_to]}'" \
@@ -14,7 +16,7 @@ module Release
         end
 
         def first_commit
-          "git rev-list --max-parents=0 HEAD"
+          "git rev-list --max-parents=0 #{DEFAULT_TAG}"
         end
 
         def last_tag
@@ -26,7 +28,7 @@ module Release
         end
 
         def read_all_tags
-          "git tag | sort -u -r"
+          "git for-each-ref --sort=taggerdate --format='%(tag)' refs/tags"
         end
 
         private

--- a/lib/release/notes/git.rb
+++ b/lib/release/notes/git.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "pry"
 
 module Release
   module Notes

--- a/lib/release/notes/link.rb
+++ b/lib/release/notes/link.rb
@@ -18,9 +18,9 @@ module Release
 
         # @api private
         def split_lines(lines)
-          lines.split("\n").each do |line|
+          lines.split(NEWLINE).each do |line|
             unless config_link_to_labels&.any? { |la| line.include? la }
-              @new_lines += "#{line}\n"
+              @new_lines += "#{line}#{NEWLINE}"
               next
             end
             split_words(line)
@@ -39,7 +39,7 @@ module Release
         # @api private
         def replace_lines(line, label, index)
           replace_words(line.split(/\s/))
-          @new_lines += "#{replace(line, @word, label, index)}\n" if @word
+          @new_lines += "#{replace(line, @word, label, index)}#{NEWLINE}" if @word
         end
 
         # @api private

--- a/lib/release/notes/log.rb
+++ b/lib/release/notes/log.rb
@@ -4,134 +4,63 @@ module Release
   module Notes
     class Log
       include Configurable
-      delegate :digest_header, :digest_title, to: :writer
-
-      def initialize
-        @_commits = []
-      end
 
       def perform
-        if config_release_notes_exist? && !config_force_rewrite
-          # Find the last tag and group all commits
-          # under a date header at the time this is run
-          find_last_tag_and_log
-        else
+        if log_from_start?
           # Find all tags and get the logs between each tag
           # run this the first time if nothing exists
           find_all_tags_and_log_all
+        else
+          # Find the last tag and group all commits
+          # under a date header at the time this is run
+          find_last_tag_and_log
         end
+
         writer.write_new_file
       end
 
       private
 
       # @api private
-      # TODO: Fix method complexity when rewriting this class
-      def copy_single_tag_of_activity(tag_from:, tag_to: "HEAD") # rubocop:disable Metrics/AbcSize
-        [config_features, config_bugs, config_misc].each_with_index do |regex, i|
-          log = System.new(tag_from: tag_from, tag_to: tag_to, label: regex, log_all: config_log_all).log
-          log_grouped_commits(title: titles[i], log: log)
-        end
-
-        return unless config_log_all
-
-        log = System.new(tag_from: tag_from, tag_to: tag_to).log
-        log_grouped_commits(title: config_log_all_title, log: log)
-      end
-
-      # @api private
-      def formatted_date(date = nil)
-        DateFormatter.new(date).humanize
-      end
-
-      # @api private
       def find_last_tag_and_log
-        last_tag = System.last_tag.strip
-        # return false unless system_log(tag_from: last_tag, label: all_labels).present?
-        if System.new(tag_from: last_tag, label: config_all_labels).log.blank?
-          log_last
-          return
-        end
-        # output the date right now
-        header_content date: formatted_date, tag: tag_to
-        copy_single_tag_of_activity(tag_from: last_tag)
+        tag_logger(System.last_tag.strip, previous_tag(0))
       end
 
       # @api private
       def find_all_tags_and_log_all
         git_all_tags.each_with_index do |ta, i|
-          header_content(
-            date: formatted_date(System.tag_date(tag: ta)),
-            tag: ta,
-          )
-
-          copy_single_tag_of_activity(
-            tag_from: previous_tag(i).strip,
-            tag_to: ta,
-          )
+          tag_logger(ta, previous_tag(i))
         end
       end
 
       # @api private
-      def log_last
-        header_content date: formatted_date, tag: git_all_tags[0]
-        copy_single_tag_of_activity(tag_from: git_all_tags[1], tag_to: git_all_tags[0])
+      def log_from_start?
+        !config_release_notes_exist? || config_force_rewrite
       end
 
       # @api private
       def git_all_tags
-        @git_all_tags ||= System.all_tags.split("\n")
-      end
-
-      # @api private
-      def header_content(**date_and_tag)
-        digest_header(date_and_tag[config_header_title_type.to_sym])
-      end
-
-      # @api private
-      def log_grouped_commits(log:, title:)
-        return unless log.present?
-
-        log_messages = log.split("\n").map { |x| x.split(/(?=-)/) }
-        commit_hashes = log_messages.flat_map { |msg| msg[0].strip }
-
-        trimmed_commit_hashes = trim_commit_hashes(commit_hashes)
-
-        digest_unique_messages(log_messages, trimmed_commit_hashes, title) if trimmed_commit_hashes.present?
-      end
-
-      # @api private
-      def digest_unique_messages(log_messages, commit_hashes, title)
-        messages = log_messages.map do |msg|
-          msg[1..-1].join if commit_hashes.include?(msg[0].strip)
-        end.compact
-
-        @_commits += commit_hashes
-
-        digest_title(title: title, log_message: "#{messages.join("\n")}\n")
-      end
-
-      # @api private
-      def trim_commit_hashes(commit_hashes)
-        commit_hashes.dup.each do |commit|
-          commit_hashes.delete commit if config_single_label && @_commits.include?(commit)
-        end
-        commit_hashes
+        @git_all_tags ||= System.all_tags.split(NEWLINE).reverse
       end
 
       # @api private
       def previous_tag(index)
-        git_all_tags[index + 1].present? ? git_all_tags[index + 1] : System.first_commit
+        git_all_tags[index + 1].yield_self { |t| tag(t) }.strip
       end
 
       # @api private
-      def titles
-        [config_feature_title, config_bug_title, config_misc_title]
+      def tag(git_tag)
+        git_tag.present? ? git_tag : System.first_commit
+      end
+
+      # @api private
+      def tag_logger(tag, previous_tag)
+        Tag.new(tag: tag, previous_tag: previous_tag, writer: writer).perform
       end
 
       # @api private
       def writer
-        @writer ||= Release::Notes::Write.new
+        @writer ||= Write.new
       end
     end
   end

--- a/lib/release/notes/tag.rb
+++ b/lib/release/notes/tag.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Release
+  module Notes
+    class Tag
+      include Configurable
+      attr_accessor :_hashes
+      attr_reader :tag, :previous_tag
+
+      delegate :digest_header, prefix: :writer, to: :@writer
+
+      def initialize(tag:, writer:, previous_tag:)
+        @tag = tag
+        @writer = writer
+        @previous_tag = previous_tag
+
+        @_commits = {}
+        @_hashes = []
+      end
+
+      def perform
+        store_commits
+
+        if commits_available?
+          writer_digest_header(header_title)
+          log_commits
+        end
+
+        self
+      end
+
+      private
+
+      # @api private
+      def commits_available?
+        @_commits.present?
+      end
+
+      # @api private
+      def formatted_date(date = nil)
+        DateFormatter.new(date).humanize
+      end
+
+      # @api private
+      def header_title
+        config_header_title.yield_self { |t| title(t) }
+      end
+
+      def log_commits
+        @_commits.each do |key, val|
+          Commits.new(title: titles[key], value: val, writer: @writer, tagger: self).perform
+        end
+      end
+
+      # @api private
+      def tag_date
+        System.tag_date(tag: tag)
+      end
+
+      # @api private
+      def store_commits
+        all_labels.each_with_index do |lab, i|
+          system_log(label: lab).tap { |str| @_commits[i] = str if str.present? }
+        end
+
+        @_commits[all_labels.size] = system_log(log_all: true) if config_log_all
+      end
+
+      # @api private
+      def system_log(**opts)
+        System.new({ tag_from: previous_tag, tag_to: tag }.merge(opts)).log
+      end
+
+      # @api private
+      def all_labels
+        [config_features, config_bugs, config_misc]
+      end
+
+      # @api private
+      def titles
+        [config_feature_title, config_bug_title,
+         config_misc_title, config_log_all_title]
+      end
+
+      # @api private
+      def title(title)
+        title == "tag" ? tag : formatted_date(tag_date)
+      end
+    end
+  end
+end

--- a/lib/release/notes/write.rb
+++ b/lib/release/notes/write.rb
@@ -46,17 +46,17 @@ module Release
 
       # @api private
       def header_present
-        "\n## #{@header}\n"
+        "#{NEWLINE}## #{@header}#{NEWLINE}"
       end
 
       # @api private
       def title_present
-        "\n#{@title}\n\n"
+        "#{NEWLINE}#{@title}#{NEWLINE}#{NEWLINE}"
       end
 
       # @api private
       def format_line
-        return "#{prettify(line: link_messages)}\n" if config_prettify_messages?
+        return "#{prettify(line: link_messages)}#{NEWLINE}" if config_prettify_messages?
 
         link_messages
       end
@@ -69,7 +69,7 @@ module Release
       # @api private
       def copy_over_notes
         File.open(config_temp_file, "a") do |f|
-          f << "\n"
+          f << NEWLINE
           IO.readlines(config_output_file)[2..-1].each { |line| f << line }
         end
       end
@@ -84,7 +84,7 @@ module Release
       # @api private
       def new_temp_file_template
         File.open(config_temp_file, "w") do |fi|
-          fi << "# Release Notes\n"
+          fi << "# Release Notes#{NEWLINE}"
         end
       end
     end

--- a/spec/release/notes/git_spec.rb
+++ b/spec/release/notes/git_spec.rb
@@ -74,7 +74,7 @@ describe Release::Notes::Git do
 
   describe ".read_all_tags" do
     it "returns command to get all tags" do
-      expect(subject.read_all_tags).to eq "git tag | sort -u -r"
+      expect(subject.read_all_tags).to eq "git for-each-ref --sort=taggerdate --format='%(tag)' refs/tags"
     end
   end
 end


### PR DESCRIPTION
This commit rewrites log.rb with some additional
files. It also makes a few additional changes including:

  - moving strings to constants
  - changing method on Git.read_all_tags

This Git change takes into account tags that may include pre/beta/alpha
and sorts it correctly (it previously wasn't sorted correctly).

This commit also drops support for ruby < 2.5 with the use of
yield_self.

Resolves https://github.com/dvmonroe/release-notes/issues/67

# Type of PR (feature, enhancement, bug fix, etc.)

## Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have rebased the branch with the latest code from master
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, and at the top of new interactors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The build is passing

## Screenshots (if applicable)

## Dependencies introduced
