### PR TITLE
fix issue#73

### DIFF
--- a/lib/release/notes/configurable.rb
+++ b/lib/release/notes/configurable.rb
@@ -9,7 +9,7 @@ module Release
                :bugs, :misc, :feature_title,
                :bug_title, :misc_title, :log_all_title, :single_label,
                :output_file, :temp_file, :link_commits?, :all_labels,
-               :prettify_messages?, :release_notes_exist?,
+               :prettify_messages?, :release_notes_exist?, :for_each_ref_format,
                :force_rewrite, prefix: :config, to: :"Release::Notes.configuration"
     end
   end

--- a/lib/release/notes/configuration.rb
+++ b/lib/release/notes/configuration.rb
@@ -126,6 +126,11 @@ module Release
       # @return [Boolean]
       attr_accessor :single_label
 
+      # Controls what will be passed to the format flag in `git for-each-ref`
+      # Defaults to `tag`.
+      # @return [String]
+      attr_accessor :for_each_ref_format
+
       def initialize
         @output_file           = "./RELEASE_NOTES.md"
         @temp_file             = "./release-notes.tmp.md"
@@ -148,6 +153,7 @@ module Release
         @prettify_messages     = false
         @force_rewrite         = false
         @single_label          = true
+        @for_each_ref_format   = "tag"
       end
 
       # @return [String]

--- a/lib/release/notes/git.rb
+++ b/lib/release/notes/git.rb
@@ -59,7 +59,7 @@ module Release
         # @return [Array] all git tags
         #
         def read_all_tags
-          "git for-each-ref --sort=taggerdate --format='%(tag)' refs/tags"
+          "git for-each-ref --sort=taggerdate --format='%(#{config_for_each_ref_format})' refs/tags"
         end
 
         private

--- a/spec/release/notes/configuration_spec.rb
+++ b/spec/release/notes/configuration_spec.rb
@@ -229,4 +229,19 @@ describe Release::Notes::Configuration do
       end
     end
   end
+
+  describe "#for_each_ref_foramt" do
+    context "when for_each_ref_format has been configured" do
+      it "returns the configured value" do
+        Release::Notes.configure { |config| config.for_each_ref_format = "refname:lstrip=-1" }
+        expect(Release::Notes.configuration.for_each_ref_format).to eq "refname:lstrip=-1"
+      end
+    end
+
+    context "when prettify_messages has not been configured" do
+      it "defaults to tag" do
+        expect(Release::Notes.configuration.for_each_ref_format).to eq "tag"
+      end
+    end
+  end
 end

--- a/spec/release/notes/configuration_spec.rb
+++ b/spec/release/notes/configuration_spec.rb
@@ -230,7 +230,7 @@ describe Release::Notes::Configuration do
     end
   end
 
-  describe "#for_each_ref_foramt" do
+  describe "#for_each_ref_format" do
     context "when for_each_ref_format has been configured" do
       it "returns the configured value" do
         Release::Notes.configure { |config| config.for_each_ref_format = "refname:lstrip=-1" }
@@ -238,7 +238,7 @@ describe Release::Notes::Configuration do
       end
     end
 
-    context "when prettify_messages has not been configured" do
+    context "when for_each_ref_format has not been configured" do
       it "defaults to tag" do
         expect(Release::Notes.configuration.for_each_ref_format).to eq "tag"
       end


### PR DESCRIPTION
# Bug fix

## Description

Allow user to specify format options for `git for-each-ref`, which will break under non-traditional tagging setups.

Fixes #73

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have rebased the branch with the latest code from master
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, and at the top of new interactors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing