### PR TITLE
remove backslash for linked labels

### DIFF
--- a/lib/release/notes/link.rb
+++ b/lib/release/notes/link.rb
@@ -97,7 +97,7 @@ module Release
         def replace(line, issue_number, label, index)
           identifier = "#{label.split(/\s/)[0]} #{issue_number}"
           humanized = "#{config_link_to_humanize[index]} #{issue_number}"
-          linked = "[#{humanized}](#{config_link_to_sites[index]}\/#{issue_number.tr('^0-9', '')})"
+          linked = "[#{humanized}](#{config_link_to_sites[index]}#{issue_number.tr('^0-9', '')})"
 
           line.gsub! identifier, linked
           line

--- a/spec/release/notes/link_spec.rb
+++ b/spec/release/notes/link_spec.rb
@@ -29,7 +29,7 @@ describe Release::Notes::Link do
       context "labels exist" do
         let(:config_link_to_labels) { ["AB #", "BC #"] }
         let(:config_link_to_humanize) { %w(LabelAB LabelBC) }
-        let(:config_link_to_sites) { ["https:\/\/label_AB\/projects", "https:\/\/label_BC\/projects"] }
+        let(:config_link_to_sites) { ["https:\/\/label_AB\/projects\/", "https:\/\/label_BC\/projects\/"] }
 
         before :each do
           allow_any_instance_of(klass).to receive(:config_link_to_labels).


### PR DESCRIPTION
# Feature

## Description

User may not want an extra slash when linking labels. 

Example: 
I want to link `example.com/myproj-888`
My `config.link_to_sites` is `https:\/\/example.com\/myproj-` will resolve to `https:\/\/example.com\/myproj-/666` when I actually want it to be `https:\/\/example.com\/myproj-666`

This commit fixes this issue. The caveat being that you will now need to format your `config.link_to_sites` for sites you do need the extra `/` in to be `https:\/\/example.com\/mylabel\/`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing