### PR TITLE
Support for repos with merged orphan branches

### DIFF
--- a/lib/release/notes/system.rb
+++ b/lib/release/notes/system.rb
@@ -38,9 +38,9 @@ module Release
         # @return [String] shell output of running Git.first_commit
         #
         def first_commit
-          parent_commits = `#{Git.first_commit}`
+          first_commits  = `#{Git.first_commit}`
 
-          parent_commits.split(Release::Notes::NEWLINE)[-1]
+          first_commits.split(Release::Notes::NEWLINE)[-1]
         end
 
         #

--- a/lib/release/notes/system.rb
+++ b/lib/release/notes/system.rb
@@ -38,7 +38,9 @@ module Release
         # @return [String] shell output of running Git.first_commit
         #
         def first_commit
-          `#{Git.first_commit}`
+          parent_commits = `#{Git.first_commit}`.split('\n')
+
+          parent_commits.split("\n")[-1]
         end
 
         #

--- a/lib/release/notes/system.rb
+++ b/lib/release/notes/system.rb
@@ -38,9 +38,9 @@ module Release
         # @return [String] shell output of running Git.first_commit
         #
         def first_commit
-          parent_commits = `#{Git.first_commit}`.split('\n')
+          parent_commits = `#{Git.first_commit}`
 
-          parent_commits.split("\n")[-1]
+          parent_commits.split(Release::Notes::NEWLINE)[-1]
         end
 
         #

--- a/spec/release/notes/system_spec.rb
+++ b/spec/release/notes/system_spec.rb
@@ -77,4 +77,16 @@ describe Release::Notes::System do
       expect(klass.tag_date).to eq "foo"
     end
   end
+
+  describe ".first_commit" do
+    it "returns the oldest parent commit of multiple" do
+      allow(Release::Notes::System).to receive(:`).and_return("merged_orphan_branch_commit\nfirst_commit")
+      expect(klass.first_commit).to eq "first_commit"
+    end
+
+    it "returns the first commit if its unique" do
+      allow(Release::Notes::System).to receive(:`).and_return("first_commit")
+      expect(klass.first_commit).to eq "first_commit"
+    end
+  end
 end


### PR DESCRIPTION
# Bug fix

## Description

The `System::first_commit` method now takes the last commit returned by `git rev-list`. This is the correct one, because rev-list orders chronologically

Fixes #83 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The build is passing
